### PR TITLE
feat: Add mobile-only scroller component

### DIFF
--- a/css/scroller.css
+++ b/css/scroller.css
@@ -1,0 +1,329 @@
+@import url('https://fonts.googleapis.com/css2?family=Reddit+Mono:wght@200..900&display=swap');
+@import url('https://unpkg.com/normalize.css') layer(normalize);
+
+@layer normalize, base, demo, snapping;
+
+@media (max-width: 768px) {
+  @layer snapping {
+    @supports (animation-timeline: scroll()) {
+      .scroller header,
+      .scroller footer {
+        scroll-snap-align: unset;
+      }
+      .scroller header {
+        --align: start;
+        animation: snap both linear reverse;
+        animation-timeline: scroll(nearest);
+        animation-range: calc(var(--padding, 0) * 1px) 0;
+      }
+      .scroller footer {
+        --align: end;
+        animation: snap both linear;
+        animation-timeline: scroll(nearest);
+        animation-range: calc(100% - (var(--padding, 0) * 1px)) 100%;
+      }
+      @keyframes snap {
+        to {
+          scroll-snap-align: var(--align, start);
+        }
+      }
+    }
+  }
+
+  @layer demo {
+    :root {
+      --size: 300px;
+      --radius: 32;
+      --padding: 64px;
+      --bg: hsl(180 0% 33%);
+      --bar: hsl(0 0% 100% / 0.5);
+      --panel: hsl(20 60% 50%);
+      timeline-scope: --scroller;
+    }
+    /**
+     * Think the idea here would be to translate a fake scrollbar up/down
+     * Clip the edges and rotate a clipped bordered element on the ends
+     * If we need the fatness, we need to go with something like a morphing SVG
+     * Or we might get away with transform-origin 100% 0 and scale 1.1 to get the thicc
+     * Might be easier to drop two SVG at each end though for that.
+     * */
+    .scroller {
+      position: relative;
+      width: clamp(300px, 50vmin, 600px);
+      aspect-ratio: 3 / 4;
+      resize: both;
+      overflow: hidden;
+      /* padding: 0 0.5rem 0 0; */
+      padding: 1rem;
+    }
+
+    .scroller img {
+      width: 100%;
+      object-fit: cover;
+      border-radius: 6px;
+      filter: contrast(1.5) grayscale(1);
+    }
+
+    .bar__thumb,
+    .bar__track {
+      opacity: 0;
+      transition: opacity 0.2s;
+    }
+
+    [data-rounded-scroll='true'] .scroller :is(.bar__thumb, .bar__track) {
+      opacity: 1;
+    }
+
+    .scroller > svg {
+      position: absolute;
+      top: 1rem;
+      bottom: 1rem;
+      right: 1rem;
+      pointer-events: none;
+      /* height: 100%; */
+      width: calc(var(--radius) * 2px);
+      overflow: visible !important;
+      z-index: 2;
+    }
+
+    [data-rounded-scroll='true'] .scroller div::-webkit-scrollbar {
+      display: none;
+    }
+
+    [data-rounded-scroll='true'] div::-webkit-scrollbar {
+      display: none;
+      opacity: 0 !important;
+    }
+
+    [data-rounded-scroll='true'] .scroller div {
+      scrollbar-width: 0;
+      scrollbar-width: none;
+      -ms-overflow-style: none;
+    }
+
+    .scroller path {
+      stroke-width: calc(var(--stroke-width) * 1px);
+    }
+
+    .bar__thumb {
+      stroke: color-mix(
+        in hsl,
+        var(--color, #fff),
+        #0000 calc((1 - var(--bar-alpha, 0.5)) * 100%)
+      );
+      stroke-dasharray: var(--thumb-size) var(--track-length);
+    }
+
+    @supports (animation-timeline: scroll()) {
+      .bar__thumb {
+        animation: scroll both linear;
+        animation-timeline: --scroller;
+      }
+    }
+
+    /* Keyframes are generated via JavaScript for dynamic stuff */
+
+    .bar__track {
+      stroke: hsl(0 0% 100% / var(--track-alpha, 0));
+    }
+
+    .scroller > div {
+      height: 100%;
+      width: 100%;
+      overflow: auto;
+      background: light-dark(#fff, #000);
+      border-radius: calc(var(--radius) * 1px);
+      display: grid;
+      grid-auto-flow: row;
+      gap: 0;
+      margin: 0;
+      padding: calc(var(--padding) * 1px) 0;
+      list-style-type: none;
+      scroll-snap-type: y mandatory;
+      scroll-timeline: --scroller;
+      scroll-behavior: smooth;
+      outline: 1px solid color-mix(in lch, canvas, canvasText);
+      outline-offset: 1px;
+    }
+
+    .scroller > div::after {
+      content: '';
+      height: calc(var(--stroke, 4) * 1px);
+      width: clamp(40px, 50%, 80px);
+      background: canvasText;
+      border-radius: 100px;
+      position: absolute;
+      bottom: calc(1rem + 4px);
+      left: 50%;
+      translate: -50% -50%;
+    }
+
+    .scroller > div > * {
+      padding-inline: 1.25rem;
+    }
+    .scroller main :not(:last-child) {
+      margin-bottom: 2rem;
+    }
+
+    .scroller main p:last-of-type {
+      opacity: 0.4;
+    }
+
+    .scroller p {
+      opacity: 0.6;
+      font-size: 0.875rem;
+    }
+
+    .scroller header {
+      scroll-snap-align: start;
+      margin-block: 2rem;
+      text-transform: uppercase;
+      font-family: 'Reddit Mono', monospace;
+    }
+
+    .scroller header div {
+      margin-block: 4rem;
+    }
+
+    .scroller header h1 {
+      font-size: 1.25rem;
+      font-weight: 300;
+      margin: 0;
+    }
+    .scroller header p {
+      margin: 0;
+      font-size: 1rem;
+      font-weight: 300;
+    }
+
+    .scroller footer {
+      scroll-snap-align: end;
+      padding-inline: 1rem;
+      text-align: center;
+      padding-block: 1rem;
+      font-size: 0.75rem;
+      opacity: 0.5;
+    }
+  }
+
+  @layer base {
+    :root {
+      --font-size-min: 16;
+      --font-size-max: 20;
+      --font-ratio-min: 1.2;
+      --font-ratio-max: 1.33;
+      --font-width-min: 375;
+      --font-width-max: 1500;
+    }
+
+    html {
+      color-scheme: light dark;
+    }
+
+    [data-theme='light'] {
+      color-scheme: light only;
+    }
+
+    [data-theme='dark'] {
+      color-scheme: dark only;
+    }
+
+    :where(.fluid) {
+      --fluid-min: calc(
+        var(--font-size-min) * pow(var(--font-ratio-min), var(--font-level, 0))
+      );
+      --fluid-max: calc(
+        var(--font-size-max) * pow(var(--font-ratio-max), var(--font-level, 0))
+      );
+      --fluid-preferred: calc(
+        (var(--fluid-max) - var(--fluid-min)) /
+          (var(--font-width-max) - var(--font-width-min))
+      );
+      --fluid-type: clamp(
+        (var(--fluid-min) / 16) * 1rem,
+        ((var(--fluid-min) / 16) * 1rem) -
+          (((var(--fluid-preferred) * var(--font-width-min)) / 16) * 1rem) +
+          (var(--fluid-preferred) * var(--variable-unit, 100vi)),
+        (var(--fluid-max) / 16) * 1rem
+      );
+      font-size: var(--fluid-type);
+    }
+
+    *,
+    *:after,
+    *:before {
+      box-sizing: border-box;
+    }
+
+    body {
+      background: light-dark(#fff, #000);
+      display: grid;
+      place-items: center;
+      min-height: 100vh;
+      font-family: 'SF Pro Text', 'SF Pro Icons', 'AOS Icons', 'Helvetica Neue',
+        Helvetica, Arial, sans-serif, system-ui;
+    }
+
+    body::before {
+      --size: 45px;
+      --line: color-mix(in hsl, canvasText, transparent 70%);
+      content: '';
+      height: 100vh;
+      width: 100vw;
+      position: fixed;
+      background: linear-gradient(
+            90deg,
+            var(--line) 1px,
+            transparent 1px var(--size)
+          )
+          50% 50% / var(--size) var(--size),
+        linear-gradient(var(--line) 1px, transparent 1px var(--size)) 50% 50% /
+          var(--size) var(--size);
+      mask: linear-gradient(-20deg, transparent 50%, white);
+      top: 0;
+      transform-style: flat;
+      pointer-events: none;
+      z-index: -1;
+    }
+
+    .bear-link {
+      color: canvasText;
+      position: fixed;
+      top: 1rem;
+      left: 1rem;
+      width: 48px;
+      aspect-ratio: 1;
+      display: grid;
+      place-items: center;
+      opacity: 0.8;
+    }
+
+    :where(.x-link, .bear-link):is(:hover, :focus-visible) {
+      opacity: 1;
+    }
+
+    .bear-link svg {
+      width: 75%;
+    }
+
+    /* Utilities */
+    .sr-only {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0, 0, 0, 0);
+      white-space: nowrap;
+      border-width: 0;
+    }
+  }
+
+  div.tp-dfwv {
+    width: 280px;
+  }
+  div.tp-dfwv * {
+    text-transform: lowercase;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -36,6 +36,7 @@
 
     <!-- Link to your custom CSS file -->
     <link rel="stylesheet" href="css/style.css">
+    <link rel="stylesheet" href="css/scroller.css">
 
     <!-- External Scripts (defer loading) -->
     <script defer src="https://unpkg.com/lucide@latest"></script>
@@ -1796,140 +1797,31 @@
             <div class="flex flex-col lg:flex-row items-center justify-between gap-12 lg:gap-6">
                 <!-- Left Side: Enhanced Interactive Phone Interface -->
                 <div class="w-full lg:w-1/2 relative perspective-1000" data-animate="slide-left" data-delay="400">
-                    <!-- Enhanced Interactive Phone Container -->
-                    <div class="phone-interface phone-interface-container relative mx-auto w-[320px] md:w-[380px] h-[600px] md:h-[700px] transform-gpu cursor-pointer group will-change-transform">
-
-                        <!-- Cosmic Background Glow -->
-                        <div class="absolute -inset-8 bg-gradient-to-br from-lime-600/30 via-blue-600/20 to-sky-600/30 rounded-full blur-3xl opacity-60 group-hover:opacity-100 transition-opacity duration-700 animate-pulse"></div>
-
-                        <!-- Main Phone Frame -->
-                        <div class="relative w-full h-full rounded-[50px] bg-gradient-to-br from-gray-900 via-gray-800 to-gray-900 border-4 border-gray-700 shadow-2xl overflow-hidden group-hover:border-lime-500/50 transition-all duration-500">
-
-                            <!-- Phone Notch -->
-                            <div class="absolute top-0 left-1/2 transform -translate-x-1/2 w-1/3 h-8 bg-gray-900 rounded-b-2xl z-30 border-x-2 border-b-2 border-gray-700"></div>
-
-                            <!-- Screen Content Area -->
-                            <div class="relative w-full h-full p-6 pt-12 rounded-[46px] bg-gradient-to-b from-gray-950 via-gray-900 to-gray-950 overflow-hidden">
-
-                                <!-- Animated Status Bar -->
-                                <div class="flex justify-between items-center mb-8 text-white/70 text-sm">
-                                    <div class="flex items-center space-x-1">
-                                        <div class="w-1 h-1 bg-green-400 rounded-full animate-pulse"></div>
-                                        <span>Nashop</span>
-                                    </div>
-                                    <div class="flex items-center space-x-2">
-                                        <i class="fas fa-wifi text-xs"></i>
-                                        <i class="fas fa-battery-three-quarters text-xs"></i>
-                                    </div>
-                                </div>
-
-                                <!-- Interactive App Interface -->
-                                <div class="space-y-6">
-
-                                    <!-- Header with animated logo -->
-                                    <div class="text-center mb-8">
-                                        <div class="inline-block relative">
-                                            <div class="w-16 h-16 mx-auto mb-3 rounded-full bg-gradient-to-br from-lime-500 to-sky-500 flex items-center justify-center animate-spin-slow">
-                                                <i data-lucide="fingerprint" class="w-8 h-8 text-white"></i>
-                                            </div>
-                                            <h3 class="text-white font-bold text-lg bg-gradient-to-r from-lime-400 to-sky-400 bg-clip-text text-transparent">Nashop Mobile</h3>
-                                        </div>
-                                    </div>
-
-                                    <!-- Animated Feature Cards -->
-                                    <div class="space-y-4">
-                                        <!-- Enhanced Shopping Card -->
-                                        <div class="feature-card-mobile bg-gradient-to-r from-blue-900/40 to-lime-900/40 border border-blue-500/30 rounded-2xl p-4 transition-all duration-500 hover:border-blue-400/50 group/card will-change-transform">
-                                            <div class="flex items-center space-x-3">
-                                                <div class="w-10 h-10 rounded-full bg-blue-500/20 flex items-center justify-center group-hover/card:bg-blue-500/30 transition-colors">
-                                                    <i data-lucide="shopping-bag" class="w-5 h-5 text-blue-400"></i>
-                                                </div>
-                                                <div class="flex-1">
-                                                    <h4 class="text-white font-semibold text-sm">Smart Shopping</h4>
-                                                    <p class="text-gray-400 text-xs">AI-powered recommendations</p>
-                                                </div>
-                                                <div class="text-blue-400 text-xs animate-pulse">●</div>
-                                            </div>
-                                        </div>
-
-                                        <!-- Token Card -->
-                                        <div class="feature-card-mobile bg-gradient-to-r from-lime-900/40 to-blue-900/40 border border-lime-500/30 rounded-2xl p-4 transform transition-all duration-500 hover:scale-105 hover:border-lime-400/50 group/card">
-                                            <div class="flex items-center space-x-3">
-                                                <div class="w-10 h-10 rounded-full bg-lime-500/20 flex items-center justify-center group-hover/card:bg-lime-500/30 transition-colors">
-                                                    <i data-lucide="coins" class="w-5 h-5 text-lime-400"></i>
-                                                </div>
-                                                <div class="flex-1">
-                                                    <h4 class="text-white font-semibold text-sm">$DAN Rewards</h4>
-                                                    <p class="text-gray-400 text-xs">Earn with every purchase</p>
-                                                </div>
-                                                <div class="text-lime-400 text-xs font-bold">+125</div>
-                                            </div>
-                                        </div>
-
-                                        <!-- Wallet Card -->
-                                        <div class="feature-card-mobile bg-gradient-to-r from-blue-900/40 to-sky-900/40 border border-blue-500/30 rounded-2xl p-4 transform transition-all duration-500 hover:scale-105 hover:border-blue-400/50 group/card">
-                                            <div class="flex items-center space-x-3">
-                                                <div class="w-10 h-10 rounded-full bg-blue-500/20 flex items-center justify-center group-hover/card:bg-blue-500/30 transition-colors">
-                                                    <i data-lucide="wallet" class="w-5 h-5 text-blue-400"></i>
-                                                </div>
-                                                <div class="flex-1">
-                                                    <h4 class="text-white font-semibold text-sm">Secure Wallet</h4>
-                                                    <p class="text-gray-400 text-xs">Multi-chain support</p>
-                                                </div>
-                                                <div class="text-blue-400 text-xs animate-pulse">🔒</div>
-                                            </div>
-                                        </div>
-                                    </div>
-
-                                    <!-- Interactive Bottom Section -->
-                                    <div class="mt-8 pt-6 border-t border-gray-700/50">
-                                        <div class="flex justify-center space-x-6">
-                                            <div class="text-center group/icon cursor-pointer">
-                                                <div class="w-12 h-12 mx-auto rounded-full bg-gradient-to-br from-lime-500/20 to-sky-500/20 flex items-center justify-center group-hover/icon:from-lime-500/40 group-hover/icon:to-sky-500/40 transition-all duration-300 group-hover/icon:scale-110">
-                                                    <i data-lucide="home" class="w-6 h-6 text-lime-400"></i>
-                                                </div>
-                                                <span class="text-xs text-gray-500 mt-1 block">Home</span>
-                                            </div>
-                                            <div class="text-center group/icon cursor-pointer">
-                                                <div class="w-12 h-12 mx-auto rounded-full bg-gradient-to-br from-blue-500/20 to-lime-500/20 flex items-center justify-center group-hover/icon:from-blue-500/40 group-hover/icon:to-lime-500/40 transition-all duration-300 group-hover/icon:scale-110">
-                                                    <i data-lucide="search" class="w-6 h-6 text-blue-400"></i>
-                                                </div>
-                                                <span class="text-xs text-gray-500 mt-1 block">Explore</span>
-                                            </div>
-                                            <div class="text-center group/icon cursor-pointer">
-                                                <div class="w-12 h-12 mx-auto rounded-full bg-gradient-to-br from-blue-500/20 to-sky-500/20 flex items-center justify-center group-hover/icon:from-blue-500/40 group-hover/icon:to-sky-500/40 transition-all duration-300 group-hover/icon:scale-110">
-                                                    <i data-lucide="user" class="w-6 h-6 text-blue-400"></i>
-                                                </div>
-                                                <span class="text-xs text-gray-500 mt-1 block">Profile</span>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-
-                                <!-- Floating Particles -->
-                                <div class="absolute top-20 left-8 w-2 h-2 bg-lime-400/60 rounded-full animate-float-slow"></div>
-                                <div class="absolute top-40 right-12 w-1 h-1 bg-sky-400/60 rounded-full animate-float-slow-reverse"></div>
-                                <div class="absolute bottom-32 left-12 w-1.5 h-1.5 bg-blue-400/60 rounded-full animate-float-slow"></div>
-                                <div class="absolute bottom-20 right-8 w-1 h-1 bg-blue-400/60 rounded-full animate-float-slow-reverse"></div>
-
-                                <!-- Screen Reflection -->
-                                <div class="absolute top-0 left-0 right-0 h-1/3 bg-gradient-to-b from-white/5 to-transparent opacity-30 pointer-events-none"></div>
-                            </div>
-
-                            <!-- Phone Frame Reflection -->
-                            <div class="absolute top-[10%] left-[10%] right-[10%] h-[20%] bg-white/3 rounded-full blur-lg transform -rotate-12 opacity-40"></div>
+                    <div class="scroller" data-rounded-scroll="true">
+                        <style></style>
+                        <svg class="scroller__bar" xmlns="http://www.w3.org/2000/svg">
+                            <path class="bar__track"></path>
+                            <path class="bar__thumb"></path>
+                        </svg>
+                        <div>
+                            <header>
+                                <h1>The Scroller</h1>
+                                <p>A mobile experience.</p>
+                                <div>A div inside header</div>
+                            </header>
+                            <main>
+                                <p>This is a custom scrollbar component that is only displayed on mobile devices. It uses GSAP for animations and Tweakpane for configuration.</p>
+                                <img src="img/partners/FROGPAY.png" alt="Frogpay partner logo" />
+                                <p>The scrollbar is styled with CSS and JavaScript to create a unique and interactive experience.</p>
+                                <img src="img/partners/reelai.png" alt="Reel AI partner logo" />
+                                <p>The content inside this scroller is just placeholder text and images.</p>
+                                <img src="img/partners/BNINER.jpg" alt="BNINER partner logo" />
+                                <p>This is the last paragraph in the main section.</p>
+                            </main>
+                            <footer>
+                                <p>&copy; 2025 Nashop</p>
+                            </footer>
                         </div>
-
-                        <!-- Orbiting Elements -->
-                        <div class="absolute -top-4 -left-4 w-8 h-8 bg-lime-500/20 rounded-full blur-sm animate-spin-slow"></div>
-                        <div class="absolute -top-4 -right-4 w-6 h-6 bg-sky-500/20 rounded-full blur-sm animate-spin-slow-reverse"></div>
-                        <div class="absolute -bottom-4 -left-4 w-6 h-6 bg-blue-500/20 rounded-full blur-sm animate-spin-slow"></div>
-                        <div class="absolute -bottom-4 -right-4 w-8 h-8 bg-blue-500/20 rounded-full blur-sm animate-spin-slow-reverse"></div>
-
-                        <!-- Data Flow Lines -->
-                        <div class="absolute top-1/4 -left-20 w-16 h-0.5 bg-gradient-to-r from-transparent via-lime-500/50 to-transparent animate-pulse"></div>
-                        <div class="absolute top-1/2 -right-20 w-16 h-0.5 bg-gradient-to-r from-transparent via-sky-500/50 to-transparent animate-pulse" style="animation-delay: 1s;"></div>
-                        <div class="absolute bottom-1/4 -left-20 w-16 h-0.5 bg-gradient-to-r from-transparent via-blue-500/50 to-transparent animate-pulse" style="animation-delay: 2s;"></div>
                     </div>
                 </div>
 
@@ -3297,6 +3189,6 @@
             }, 1000);
         });
     </script>
-
+    <script type="module" src="js/scroller.js" defer></script>
 </body>
 </html>

--- a/js/scroller.js
+++ b/js/scroller.js
@@ -1,0 +1,277 @@
+import gsap from 'https://cdn.skypack.dev/gsap@3.12.0'
+import { ScrollTrigger } from 'https://cdn.skypack.dev/gsap@3.12.0/ScrollTrigger'
+import { Pane } from 'https://cdn.skypack.dev/tweakpane@4.0.4'
+
+let tl
+let configureTimeline
+
+const ctrl = new Pane({
+  title: 'Config',
+  expanded: true,
+})
+
+const scroller = document.querySelector('.scroller')
+const list = scroller.querySelector('div')
+const bar = scroller.querySelector('.scroller__bar')
+const track = scroller.querySelector('.bar__track')
+const thumb = bar.querySelector('.bar__thumb')
+const styles = scroller.querySelector('style')
+
+const config = {
+  theme: 'dark',
+  show: true,
+  radius: 32,
+  scrollPadding: 60,
+  stroke: 5,
+  inset: 6,
+  trail: 20,
+  thumb: 70,
+  finish: 5,
+  alpha: 0.9,
+  track: 0,
+  color: '#f85922',
+  cornerLength: 0,
+  offsetCorner: -50,
+  offsetEnd: 30,
+}
+
+/**
+ * Set up a ResizeObserver that syncs the SVG path and viewBox
+ * with the size of the scroller. If you have a static sized scroller
+ * and radius, etc. You can take a snapshot of it and use it over and over.
+ * The ResizeObserver is mainly for demo purposes so you can make what you
+ * want.
+ * */
+let frames = []
+const syncBar = (scrollerBar) => {
+  const mid = config.radius
+  const innerRad = Math.max(
+    0,
+    config.radius - (config.inset + config.stroke * 0.5)
+  )
+  const padTop = config.inset + config.stroke * 0.5
+  const padLeft = config.radius * 2 - padTop
+  bar.setAttribute(
+    'viewBox',
+    `0 0 ${config.radius * 2} ${scrollerBar.target.offsetHeight}`
+  )
+  scroller.style.setProperty('--stroke-width', config.stroke)
+  let d = `
+  M${mid - config.trail},${padTop}
+    ${innerRad === 0 ? '' : `L${mid},${padTop}`}
+    ${
+      innerRad === 0
+        ? `L${padLeft},${padTop}`
+        : `a${innerRad},${innerRad} 0 0 1 ${innerRad} ${innerRad}`
+    }`
+  thumb.setAttribute('d', d)
+  const cornerLength = Math.ceil(thumb.getTotalLength())
+  config.cornerLength = cornerLength
+  d = `
+    M${mid - config.trail},${padTop}
+    ${innerRad === 0 ? '' : `L${mid},${padTop}`}
+    ${
+      innerRad === 0
+        ? `L${padLeft},${padTop}`
+        : `a${innerRad},${innerRad} 0 0 1 ${innerRad} ${innerRad}`
+    }
+    L${padLeft},${
+    scrollerBar.target.offsetHeight -
+    (config.inset + config.stroke * 0.5 + innerRad)
+  }
+    ${
+      innerRad === 0
+        ? `L${padLeft},${
+            scrollerBar.target.offsetHeight -
+            (config.inset + config.stroke * 0.5)
+          }`
+        : `a${innerRad},${innerRad} 0 0 1 ${-innerRad} ${innerRad}`
+    }
+    L${mid - config.trail},${
+    scrollerBar.target.offsetHeight - (config.inset + config.stroke * 0.5)
+  }
+  `
+  thumb.setAttribute('d', d)
+  track.setAttribute('d', d)
+  scroller.style.setProperty(
+    '--track-length',
+    Math.ceil(track.getTotalLength())
+  )
+  scroller.style.setProperty('--track-start', cornerLength)
+  scroller.style.setProperty('--start', config.thumb * 2 + cornerLength)
+  scroller.style.setProperty(
+    '--destination',
+    Math.ceil(track.getTotalLength()) - cornerLength + config.thumb
+  )
+  frames = [
+    [0, config.thumb - config.finish - config.offsetEnd],
+    [
+      Math.floor(
+        (config.scrollPadding / (list.scrollHeight - scroller.offsetHeight)) *
+          100
+      ),
+      (cornerLength + config.offsetCorner) * -1,
+    ],
+    [
+      100 -
+        Math.floor(
+          (config.scrollPadding / (list.scrollHeight - scroller.offsetHeight)) *
+            100
+        ),
+      (Math.floor(track.getTotalLength()) -
+        cornerLength -
+        config.thumb -
+        config.offsetCorner) *
+        -1,
+    ],
+    [
+      100,
+      (Math.floor(track.getTotalLength()) - config.finish - config.offsetEnd) *
+        -1,
+    ],
+  ]
+  styles.innerHTML = `
+    @keyframes scroll {
+      ${frames[0][0]}% { stroke-dashoffset: ${frames[0][1]};}
+      ${frames[1][0]}% { stroke-dashoffset: ${frames[1][1]};}
+      ${frames[2][0]}% { stroke-dashoffset: ${frames[2][1]};}
+      ${frames[3][0]}% { stroke-dashoffset: ${frames[3][1]};}
+    }
+  `
+}
+
+const resizeObserver = new ResizeObserver((entries) => {
+  for (const entry of entries) {
+    syncBar(entry)
+    update()
+    if (configureTimeline && !CSS.supports('animation-timeline: scroll()'))
+      configureTimeline()
+  }
+})
+resizeObserver.observe(scroller)
+
+// if (config.show) document.documentElement.toggleAttribute('data-rounded-scroll')
+// const configFolder = CTRL.addFolder('Config')
+const update = () => {
+  document.documentElement.dataset.theme = config.theme
+  document.documentElement.dataset.roundedScroll = config.show
+  scroller.style.setProperty('--radius', config.radius)
+  scroller.style.setProperty('--padding', config.scrollPadding)
+  scroller.style.setProperty('--color', config.color)
+  scroller.style.setProperty('--thumb-size', config.thumb)
+  scroller.style.setProperty('--bar-alpha', config.alpha)
+  scroller.style.setProperty('--track-alpha', config.track)
+  scroller.style.setProperty(
+    '--destination',
+    Math.ceil(track.getTotalLength()) -
+      ((Math.ceil(track.getTotalLength()) - scroller.offsetHeight) * 0.5 +
+        config.inset)
+  )
+  scroller.style.setProperty('--start', config.thumb * 2)
+  syncBar({ target: list })
+}
+
+const setup = ctrl.addFolder({ title: 'setup', expanded: false })
+setup.addBinding(config, 'radius', {
+  min: 2,
+  max: 64,
+  step: 1,
+  label: 'Radius',
+})
+setup.addBinding(config, 'scrollPadding', {
+  min: 10,
+  max: 200,
+  step: 1,
+  label: 'Padding',
+})
+setup.addBinding(config, 'stroke', {
+  min: 1,
+  max: 20,
+  step: 1,
+  label: 'Stroke',
+})
+setup.addBinding(config, 'inset', {
+  min: 0,
+  max: 20,
+  step: 1,
+  label: 'Inset',
+})
+setup.addBinding(config, 'trail', {
+  min: 0,
+  max: 100,
+  step: 1,
+  label: 'Trail',
+})
+setup.addBinding(config, 'thumb', {
+  min: 20,
+  max: 200,
+  step: 1,
+  label: 'Thumb',
+})
+setup.addBinding(config, 'thumb', {
+  min: 5,
+  max: 50,
+  step: 1,
+  label: 'Finish',
+})
+setup.addBinding(config, 'alpha', {
+  min: 0.1,
+  max: 1,
+  step: 0.01,
+  label: 'Thumb Alpha',
+})
+setup.addBinding(config, 'track', {
+  min: 0.1,
+  max: 1,
+  step: 0.01,
+  label: 'Track Alpha',
+})
+setup.addBinding(config, 'offsetCorner', {
+  min: -50,
+  max: 50,
+  step: 1,
+  label: 'Offset start',
+})
+setup.addBinding(config, 'offsetEnd', {
+  min: -50,
+  max: 50,
+  step: 1,
+  label: 'Offset end',
+})
+setup.addBinding(config, 'color', {
+  label: 'Color',
+})
+ctrl.addBinding(config, 'show', {
+  label: 'Enable',
+})
+ctrl.addBinding(config, 'theme', {
+  label: 'Theme',
+  options: {
+    System: 'system',
+    Light: 'light',
+    Dark: 'dark',
+  },
+})
+ctrl.on('change', update)
+
+syncBar({ target: scroller })
+if (!CSS.supports('(animation-timeline: scroll())')) {
+  configureTimeline = () => {
+    if (tl) tl.kill()
+    tl = gsap.to('.bar__thumb', {
+      scrollTrigger: {
+        scroller: list,
+        scrub: true,
+      },
+      ease: 'none',
+      keyframes: {
+        [`${frames[0][0]}`]: { strokeDashoffset: frames[0][1] },
+        [`${frames[1][0]}`]: { strokeDashoffset: frames[1][1] },
+        [`${frames[2][0]}`]: { strokeDashoffset: frames[2][1] },
+        [`${frames[3][0]}`]: { strokeDashoffset: frames[3][1] },
+      },
+    })
+  }
+  gsap.registerPlugin(ScrollTrigger)
+  configureTimeline()
+}


### PR DESCRIPTION
This commit introduces a new interactive scroller component that is displayed on mobile devices.

The new component replaces the phone mockup in the 'Mobile Experience' section of the `index.html` page.

- A new CSS file `css/scroller.css` is added with the styles for the component, wrapped in a `@media (max-width: 768px)` block.
- A new JavaScript file `js/scroller.js` is added to handle the animations and interactivity of the scroller.
- The `index.html` file is updated to include the HTML for the scroller, the new stylesheet, and the new JavaScript module.